### PR TITLE
fix: clean up Docker release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Verify Docker Hub connectivity
-      - name: Verify Docker Hub connectivity
-        run: |
-          echo "Testing Docker Hub connectivity..."
-          docker pull hello-world
-          docker tag hello-world ${{ secrets.DOCKERHUB_USERNAME }}/test:connectivity-test
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/test:connectivity-test || echo "Push test failed, but continuing..."
-          docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/test:connectivity-test || true
-
       # --- Metadata ---
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -54,13 +45,6 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') && startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Debug metadata output
-        run: |
-          echo "Generated tags:"
-          echo "${{ steps.meta.outputs.tags }}"
-          echo "Generated labels:"
-          echo "${{ steps.meta.outputs.labels }}"
 
       # --- Build and Push ---
       - name: Build and push Docker image
@@ -77,23 +61,7 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: false
           sbom: false
-        continue-on-error: true
 
-      # Fallback: Try pushing each tag individually if multi-tag push failed
-      - name: Push individual tags (fallback)
-        if: steps.build-push.outcome == 'failure'
-        run: |
-          echo "Multi-tag push failed, trying individual tags..."
-          TAGS="${{ steps.meta.outputs.tags }}"
-          for tag in $TAGS; do
-            echo "Pushing $tag..."
-            docker buildx build \
-              --platform linux/amd64,linux/arm64 \
-              --push \
-              --tag "$tag" \
-              --label="${{ steps.meta.outputs.labels }}" \
-              . || echo "Failed to push $tag"
-          done
 
       # --- Changelog Generation ---
       - name: Generate Changelog


### PR DESCRIPTION
## Summary
- Removed Docker Hub connectivity test that was added for debugging
- Removed `continue-on-error` flag to make push failures visible
- Cleaned up unnecessary fallback mechanisms and debug output

## Context
The Docker push to Docker Hub is working correctly (as confirmed by the logs). The debugging steps that were previously added are no longer necessary and were adding complexity to the workflow.

The workflow now:
1. Logs into Docker Hub
2. Builds multi-platform images (linux/amd64, linux/arm64)  
3. Pushes directly to `docker.io/jaybrueder/pf2-encounterbrew`
4. Fails visibly if there are any issues

## Test plan
- [ ] Verify workflow runs successfully on next release tag
- [ ] Confirm images appear on Docker Hub with correct tags
- [ ] Check that workflow fails properly if credentials are incorrect

🤖 Generated with [Claude Code](https://claude.ai/code)