### PR TITLE
fix: use DOCKERHUB_USERNAME secret in Docker image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            jaybrueder/pf2-encounterbrew
+            ${{ secrets.DOCKERHUB_USERNAME }}/pf2-encounterbrew
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') && startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary
- Fixed Docker Hub push issue by using the `DOCKERHUB_USERNAME` secret in the image name
- Ensures consistency between the authenticated user and the target repository

## Problem
The workflow was hardcoding 'jaybrueder' as the Docker Hub username in the metadata action but using the `DOCKERHUB_USERNAME` secret for authentication. This could cause a mismatch if the secret value differs from the hardcoded name, resulting in images being pushed to a different repository than expected.

## Solution
Changed the image name from `jaybrueder/pf2-encounterbrew` to `${{ secrets.DOCKERHUB_USERNAME }}/pf2-encounterbrew` to ensure the image is always pushed to the repository that matches the authenticated user.

## Test plan
- [ ] Verify GitHub Actions secrets are configured correctly
- [ ] Create a new release tag to trigger the workflow
- [ ] Confirm the Docker image appears in the correct DockerHub repository

🤖 Generated with [Claude Code](https://claude.ai/code)